### PR TITLE
feat(de): German 7.4.1 DSGVO launch blog post

### DIFF
--- a/content/de/blog/2026-07-08-741-de-locale.md
+++ b/content/de/blog/2026-07-08-741-de-locale.md
@@ -1,0 +1,72 @@
+---
+title: "Kirchendaten in Ihrer Hand: ChurchCRM 7.4.1 and DSGVO-Compliant Church Administration"
+date: "2026-07-08"
+lastmod: "2026-07-08"
+author: "George Dawoud"
+description: "ChurchCRM 7.4.1 gives German-speaking Kirchengemeinden DSGVO-compliant, self-hosted church management — open-source, free forever, fully auditable."
+summary: "German churches deserve software they can audit, control, and fully trust. ChurchCRM 7.4.1 delivers DSGVO-compliant, self-hosted church administration — free, open-source, and built for communities of every size and background."
+keywords: "DSGVO, Kirchenverwaltung, ChurchCRM, open source, selbst gehostet, Kirchensoftware, Datenschutz, Gemeindeverwaltung"
+tags: ["DSGVO", "open-source", "self-hosted", "church-administration", "German", "Kirchenverwaltung", "localization", "release"]
+featured_image: "/images/blogs/741-de.png"
+featured_image_alt: "ChurchCRM 7.4.1 — DSGVO-compliant self-hosted church management software for German-speaking Kirchengemeinden"
+---
+
+## Ihre Kirchengemeinde verdient Software, der Sie vertrauen können
+
+The Datenschutz-Grundverordnung — DSGVO — did not emerge from bureaucracy. It emerged from a culture. Germany has long understood that data is not just information; it is identity, dignity, and power. When your Kirchengemeinde collects names, addresses, baptism records, pastoral counseling notes, and family relationships, you are holding something sacred. That data belongs to the people you serve — and by law, it must stay under your control.
+
+That is why we built ChurchCRM the way we did: free, open-source, and designed to run on your own server from day one.
+
+## The DSGVO Problem With Cloud-Based Church Software
+
+Most commercial church management platforms are cloud-hosted. Your congregation's data lives on servers you do not own, in data centers you have never visited, operated by companies whose privacy policies can change without notice. When a US-based SaaS vendor stores your members' personal data, you face real DSGVO exposure: unclear data processing agreements, opaque sub-processor chains, and a fundamental loss of control over data that belongs to your Kirchenmitglieder.
+
+DSGVO Article 32 requires that you implement appropriate technical and organizational measures to protect personal data. Delegating that data to a third-party cloud provider is not a measure — it is an accountability gap that no Auftragsverarbeitungsvertrag can fully close.
+
+ChurchCRM is different. You install it. You own the server. You control the database. No data ever leaves your infrastructure unless you send it. And because every line of source code is publicly available under the MIT license — every database schema, every access control, every data retention path — your IT volunteers, your Kirchenrechenzentrum, or any certified Datenschutzbeauftragter can audit it completely. That is not a feature. That is the architecture.
+
+## Built for Every Kirchengemeinde in the German-Speaking World
+
+Germany's religious landscape is richer and more varied than any single tradition. The historic Protestant Landeskirchen and Catholic Bistümer run large, well-resourced parish offices with professional Gemeindeverwaltung staff who expect precision, documentation, and compliance. But across German cities — in Berlin, Frankfurt, Hamburg, Munich, and Stuttgart — a growing network of immigrant evangelical churches, Arabic-speaking congregations, and Eastern European communities serves members who face real financial barriers. For these communities, "affordable" is not enough. Free is the only option.
+
+ChurchCRM is genuinely free. Not a free tier. Not a freemium bait-and-switch. MIT-licensed, no per-member fees, no expiring trials, no upsell path. A congregation of twenty members and a Landeskirchliche Einrichtung with ten thousand records run on exactly the same software, with exactly the same capabilities.
+
+Austria and Switzerland face equivalent realities: Austria's Datenschutzgesetz (DSG) and Switzerland's revDSG both align closely with DSGVO in principle and intent. Self-hosting is the cleanest, most defensible compliance path in all three countries — and the only one that puts your church, not a vendor, in control.
+
+## What's New in ChurchCRM 7.4.1
+
+Version 7.4.1 continues a steady, community-driven evolution of the platform. Here is what matters most to church office staff and administrators:
+
+### Simplified Permissions — Finally in Plain Language
+
+We have rewritten the user permissions system using clear, plain-language labels that anyone can understand without consulting a manual. Kirchenbüro managers no longer need to decode cryptic permission names to decide what a new volunteer should be allowed to do. Smart dashboard buttons now automatically hide actions a user cannot perform, reducing confusion and accidental data exposure.
+
+### EditSelf Mode — Member Autonomy With Privacy Protection
+
+The new exclusive EditSelf permission mode lets congregation members update their own contact information without being able to view or edit anyone else's records. This is a direct DSGVO alignment: members hold rights of access and rectification under Articles 15 and 16, and EditSelf makes honoring those rights practical without creating administrative overhead.
+
+### GDPR-Friendly Privacy Guardrails Built In
+
+Privacy protection is now structural, not optional. We have embedded privacy-respecting defaults directly into the administrative workflow, guiding staff toward compliant choices rather than relying on training alone to prevent mistakes.
+
+### A Centralized Localization Hub
+
+The new admin/system/localization panel brings all language and regional settings into one place. For churches operating in multilingual environments — common in Germany's immigrant communities — configuring ChurchCRM for a bilingual congregation is now straightforward.
+
+### 55+ Languages and Growing
+
+Version 7.4.1 ships the Croatian (hr_HR) locale, bringing ChurchCRM to 55+ languages worldwide. A Croatian diaspora congregation in Vienna, a multilingual parish in Basel, a Landeskirche with international ministry staff — our localization library covers a breadth that no single commercial vendor can match, because it is built by the communities who need it.
+
+## Help Shape ChurchCRM for German-Speaking Communities
+
+The German locale is strong — but every language deepens with community voices who know the specific vocabulary of Kirchenverwaltung, pastoral practice, and regional church structures in Germany, Austria, and Switzerland. If you are a native German speaker serving in church administration, your contribution on [POEditor](https://poeditor.com/join/project/lEluFJMi0W) directly improves ChurchCRM for thousands of Kirchengemeinden worldwide.
+
+Join the global conversation on our [Community Discord](https://discord.gg/tuWyFzj3Nj), where church administrators, developers, and ministry leaders from more than 55 language communities share advice, feedback, and support.
+
+When you are ready to deploy: full documentation, installation guides, and downloads are at [churchcrm.io](https://churchcrm.io). Self-hosting takes an afternoon. The compliance clarity it delivers lasts for years.
+
+DSGVO-konform. Selbst gehostet. Open Source. Ihre Kirchendaten bleiben bei Ihrer Kirche.
+
+---
+
+ChurchCRM is free, open-source church management software used by congregations in 55+ languages worldwide. [Download ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Community Discord](https://discord.gg/tuWyFzj3Nj)

--- a/content/de/blog/_index.md
+++ b/content/de/blog/_index.md
@@ -1,0 +1,6 @@
+---
+title: "ChurchCRM Blog"
+description: "Tipps, Anleitungen und Neuigkeiten aus der ChurchCRM-Community — rund um Kirchenverwaltung, Datenschutz, Open-Source und bewährte Praktiken für jede Gemeinde."
+date: "2026-07-08"
+lastmod: "2026-07-08"
+---


### PR DESCRIPTION
Adds a German-language blog post for the ChurchCRM 7.4.1 launch, targeting Kirchengemeinden in Germany, Austria, and Switzerland.

## Changes

- `content/de/blog/_index.md` — German blog section index (new)
- `content/de/blog/2026-07-08-741-de-locale.md` — full launch post (German)

No `hugo.toml` changes needed — `[languages.de]` already configured.

## Content summary

The post covers:
- DSGVO/data sovereignty architecture (self-hosted, fully auditable)
- Why cloud-based church software creates DSGVO exposure
- Relevance for Landeskirchen, Catholic Bistümer, and immigrant evangelical communities across DACH
- 7.4.1 feature highlights: simplified permissions, EditSelf mode, privacy guardrails, localization hub
- Austria DSG + Switzerland revDSG coverage
- CTA to POEditor + Discord

## Source

Content approved via ChurchCRM/marketing PR #22 (blog/741-de branch).

---
🔁 Part of the 7.4.1 regional launch campaign (9-language blog series). Day 3.