### PR TITLE
feat(es): Spanish 7.4.1 Latin America launch blog post

### DIFF
--- a/content/es/blog/2026-07-09-741-es-locale.md
+++ b/content/es/blog/2026-07-09-741-es-locale.md
@@ -1,0 +1,84 @@
+---
+title: "Every Iglesia Deserves Great Tools: ChurchCRM 7.4.1 and the Latin American Church Boom"
+date: "2026-07-09"
+lastmod: "2026-07-09"
+author: "George Dawoud"
+description: "ChurchCRM 7.4.1 brings 55+ language support and smarter permissions to the world's fastest-growing church sector — at zero cost, forever."
+summary: "Latin America's evangelical and Pentecostal churches are growing faster than any other faith sector on earth. ChurchCRM 7.4.1 gives every new congregación the management tools of a mega-church — free, self-hosted, and built by the community."
+keywords: "ChurchCRM Spanish, church management software Latin America, free church software, open source iglesia, evangelical church tools, ChurchCRM 7.4.1, self-hosted church CRM, ChurchCRM localization"
+tags: ["release", "localization", "latin-america", "open-source", "community", "7.4.1"]
+featured_image: "/images/blogs/741-es.png"
+featured_image_alt: "ChurchCRM 7.4.1 supporting Spanish-speaking churches across Latin America and beyond"
+---
+
+There is a church planting movement happening right now that most of the tech world is completely ignoring. Across Mexico, Colombia, Argentina, Chile, Brazil's Spanish-speaking communities, and hundreds of cities in between, new evangelical and Pentecostal congregations are forming every single week. Grassroots, Spirit-led, and built on relational faith — the kind of *iglesia* where the pastor knows every family by name, and the hermanas in the women's ministry coordinate everything over WhatsApp.
+
+These churches are not small because they lack vision. They are new. And they deserve tools that match their ambition.
+
+That is exactly what we built ChurchCRM for.
+
+## The Fastest-Growing Church Sector on Earth
+
+Latin America's evangelical and Pentecostal communities represent one of the most extraordinary expansions in the history of Christianity. Researchers estimate that tens of thousands of new congregations form across the region each year — many of them meeting in homes, storefronts, rented halls, and open-air plazas. The growth is not driven by denominations with IT departments and software budgets. It is driven by *pastores* with a calling, *voluntarios* with laptops, and *congregaciones* that run on faith and paper registers.
+
+And here is the reality those communities face every day: the administrative tools built for churches were designed for large, wealthy organizations in North America and Europe. They charge per member. They lock your data behind proprietary systems. They assume you have a dedicated staff and a tech-comfortable admin who speaks English.
+
+Most of the growing church world does not look like that. It never did.
+
+## Why Self-Hosting Changes Everything Here
+
+When a church in Medellín, Guadalajara, or Buenos Aires pays a per-member fee to manage its congregation, that money does not go back to the mission. It goes to a software vendor thousands of miles away who has never heard a Sunday service in Spanish, never seen a congregación multiply out of a living room, and has no idea what stewardship means to a community building something from nothing.
+
+Self-hosting is not just a technical preference. For a growing *iglesia* with no IT budget, it is an act of financial stewardship. You install it once. You own your data. The cost is zero — forever.
+
+No per-member fees. No lock-in. No vendor deciding what your church data is worth.
+
+That is the promise of open source, and it is exactly why ChurchCRM is MIT-licensed and always will be.
+
+## What ChurchCRM 7.4.1 Brings
+
+Version 7.4.1 is a release built with the global church community in mind. Here is what it delivers:
+
+### 55+ Languages — and Growing
+
+With the addition of Croatian (hr_HR), we now ship in over 55 languages. Spanish has been supported for years, and this release reinforces our commitment to keeping every locale polished and current. If you have ever wished your ChurchCRM interface felt more natural in your regional dialect — or if you want to contribute to the Spanish translation — the door is wide open at [POEditor](https://poeditor.com/join/project/lEluFJMi0W).
+
+### Smarter Permissions, Plain Language
+
+One of the biggest barriers for volunteer-run churches is permissions complexity. Who can see what? Who accidentally deletes the membership list? Version 7.4.1 redesigns the user permissions system with plain-language labels and an exclusive **EditSelf** permission mode — so a volunteer can update their own profile without ever touching anyone else's record. That is real trust, built into the software.
+
+### Smart Dashboard — No Confusion, No Clutter
+
+When a new volunteer logs in and sees buttons for actions they cannot access, it creates confusion and support requests. The new smart dashboard hides inaccessible actions automatically. Your team sees exactly what they can do — nothing more, nothing less. Clean, intuitive, and ready for the *hermano* who just joined the admin team last Sunday.
+
+### GDPR-Friendly Privacy Guardrails
+
+Data privacy matters everywhere — including in regions where it is not yet legally mandated. We have added GDPR-friendly privacy guardrails so you can build a culture of data stewardship from day one, before it becomes a requirement.
+
+### New Localization Hub
+
+Find everything in one place: **Admin → System → Localization**. Language settings, regional formats, locale management — all consolidated so your administrator does not have to hunt through menus.
+
+## From WhatsApp Groups to a Real Database
+
+We know how most growing churches actually manage their members right now: a WhatsApp group for the worship team, a spreadsheet someone made in 2019, a paper register that lives in the pastor's briefcase, and a lot of memory in the heads of a few key volunteers.
+
+When that volunteer moves. When the phone gets lost. When the congregation grows past 80 people and no one can remember who was baptized when — the cracks start to show.
+
+ChurchCRM is the upgrade that does not require a budget. Install it on a $5/month server, a donated computer running locally, or a shared hosting plan your tech-savvy *hermano* already has. Import your members. Start tracking attendance, pledges, groups, and events. Your data stays yours — private, portable, and free from any vendor's terms of service.
+
+## Join Us — Build the Tools the Global Church Deserves
+
+ChurchCRM has 903 GitHub stars, 551 forks, and more than ten years of community behind it. But the work is never finished. Every translation contribution, every bug report, every pull request from a developer in Bogotá or Madrid or Chicago makes the software better for every *iglesia* on earth.
+
+**Want to help translate ChurchCRM into your regional Spanish variant?** Join the translation project at [POEditor](https://poeditor.com/join/project/lEluFJMi0W) — it takes minutes to start, and your contribution ships to thousands of churches.
+
+**Have questions or want to connect with the community?** Join our [Discord server](https://discord.gg/tuWyFzj3Nj) — hermanos and hermanas from around the world are there.
+
+**Ready to install?** Head to [churchcrm.io](https://churchcrm.io) and get started today.
+
+Every *iglesia* deserves great tools. This one is yours — no strings attached.
+
+---
+
+*ChurchCRM is free, open-source church management software used by congregations in 55+ languages worldwide. [Download ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Community Discord](https://discord.gg/tuWyFzj3Nj)*

--- a/content/es/blog/_index.md
+++ b/content/es/blog/_index.md
@@ -1,0 +1,6 @@
+---
+title: "ChurchCRM Blog"
+description: "Consejos, guías y noticias de la comunidad ChurchCRM — sobre gestión de iglesias, seguridad, código abierto y mejores prácticas para cada congregación."
+date: "2026-07-09"
+lastmod: "2026-07-09"
+---


### PR DESCRIPTION
Adds a Spanish-language blog post for the ChurchCRM 7.4.1 launch, targeting evangelical and Pentecostal churches across Latin America and Spanish-speaking communities worldwide.

## Changes

- `content/es/blog/_index.md` — Spanish blog section index (new)
- `content/es/blog/2026-07-09-741-es-locale.md` — full launch post (Spanish)

No `hugo.toml` changes needed — `[languages.es]` already configured.

## Content summary

The post covers:
- Latin America church planting boom context
- Why self-hosting is an act of financial stewardship for zero-budget iglesias
- The per-member fee problem with North American/European SaaS vendors
- 7.4.1 features: 55+ languages, EditSelf permissions, smart dashboard, privacy guardrails, localization hub
- CTA to POEditor, Discord, and churchcrm.io

## Source

Content sourced from ChurchCRM/marketing PR #25 (blog/741-es branch).

---
🔁 Part of the 7.4.1 regional launch campaign (9-language blog series). Day 4.