### PR TITLE
Blog: Croatian post (7.4.1 hr_HR) — single blog structure

### DIFF
--- a/content/en/blog/2026-07-07-741-hr-locale.md
+++ b/content/en/blog/2026-07-07-741-hr-locale.md
@@ -1,0 +1,75 @@
+---
+title: "ChurchCRM 7.4.1: Dobrodošli — Vaš jezik. Vaši podaci. Vaša crkva."
+date: "2026-07-07"
+lastmod: "2026-07-07"
+author: "George Dawoud"
+language: "hr"
+description: "ChurchCRM 7.4.1 donosi hrvatski jezik (hr_HR). Besplatni open-source softver za upravljanje župom — bez naknada, bez lock-ina, vaši podaci ostaju na vašem poslužitelju."
+summary: "ChurchCRM 7.4.1 uvodi puni hrvatski jezik zahvaljujući volonteru iz zajednice. Saznajte zašto je ovo važno za katoličke župe, evangeličke i baptističke zajednice u Hrvatskoj i BiH — i za dijasporu širom svijeta."
+keywords: "ChurchCRM hrvatski, crkveni softver hrvatska, upravljanje župom, open source crkva, GDPR crkveni softver, besplatni župni softver, ChurchCRM 7.4.1, hr_HR lokalizacija"
+tags: ["lokalizacija", "7.4.1", "hrvatska", "open-source", "župni softver", "GDPR", "bosna-hercegovina"]
+featured_image: "/images/blogs/741-hr.png"
+featured_image_alt: "ChurchCRM 7.4.1 s hrvatskim sučeljem — Dobrodošli, hrvatske crkve"
+image_credit: "[placeholder — Zagreb Cathedral photo to be added via Canvora]"
+---
+
+Zamislite taj trenutak: otvorite softver koji koristite svaki dan za upravljanje vašom župom — i sve je na hrvatskom. Izbornici, gumbi, poruke, izvješća. Vaš jezik. Odmah, bez prijevoda u glavi, bez pretpostavljanja što koji engleski pojam znači u crkvenom kontekstu.
+
+To je ono što donosi ChurchCRM 7.4.1.
+
+## Netko je to napravio za vas
+
+Hrvatska lokalizacija nije nastala u uredu negdje daleko. Nastala je zahvaljujući volonteru iz naše zajednice — nekome tko poznaje hrvatske župe, tko razumije kako se kaže "membership" u kontekstu zajednice vjernika, tko je sjeo i marljivo preveo svaki pojam, svaku poruku, svaki gumb.
+
+To je snaga open-source projekta: kad netko u zajednici osjeti potrebu, može je ispuniti — i pokloniti to svima. Više od 903 zvjezdica na GitHubu, 551 fork-ova, deset godina razvoja — iza svakog od tih brojeva stoji čovjek koji je odlučio doprinijeti nešto vrijedno.
+
+Danas je taj čovjek dao glas vašoj crkvi.
+
+## Zašto je ovo važno za Hrvatsku — i Bosnu i Hercegovinu
+
+Hrvatska ima bogatu crkvenu tradiciju. Katoličke župe, evangeličke i baptističke zajednice, reformirane crkve — sve one svakodnevno vode evidenciju članova, organiziraju skupove, upravljaju donacijama i brinu se o zajednici.
+
+Dosad je mnogo tih zajednica radilo s engleskim sučeljem, ili s naslijeđenim Excel tablicama. Ni jedno ni drugo nije idealno za župnog administratora ili pastora koji jednostavno želi znati koliko obitelji redovito dolazi, ili tko treba posjet u bolnici.
+
+S hrvatskim sučeljem u ChurchCRM-u, ta prepreka nestaje.
+
+A za zajednice u Bosni i Hercegovini — koje dijele jezik, kulturu i iste crkvene tradicije — ova verzija znači jednako. Nema granica kad je u pitanju vaša zajednica vjernika.
+
+I za hrvatsku dijasporu u Njemačkoj, Austriji, SAD-u, Australiji i dalje — za sve one zajednice koje na drugom kraju svijeta čuvaju vjeru i jezik — ovo je softver koji govori vaš jezik.
+
+## GDPR i samohostanje: vaši podaci ostaju kod vas
+
+Hrvatska je članica Europske unije, i GDPR nije apstraktni pojam — to je zakonska obveza. Podaci vaših vjernika moraju biti zaštićeni, pohranjeni sigurno i dostupni isključivo onima kojima vi date ovlast.
+
+ChurchCRM je dizajniran upravo za to. Radi se o self-hosted softveru koji instalirate na vlastiti poslužitelj. Vaši podaci **nikada ne napuštaju vašu infrastrukturu**. Nema oblaka trećih strana, nema pretplate koja vas veže, nema skrivenih uvjeta koji govore tko ima pristup vašim podacima o članovima zajednice.
+
+ChurchCRM 7.4.1 donosi i nova GDPR-friendly zaštitna ograničenja privatnosti, ugrađena direktno u sustav upravljanja korisničkim pravima. Sigurnost nije dodatak — ona je dio temelja.
+
+A cijena? Besplatno. Uvijek. MIT licenca, open source, bez naknade po članu, bez godišnjih pretplata, bez lock-ina.
+
+## Što još donosi verzija 7.4.1
+
+Osim hrvatskog sučelja, ova verzija donosi nekoliko poboljšanja koja će svaka zajednica odmah osjetiti:
+
+- **Jednostavnije upravljanje pravima korisnika** — umjesto tehničkog žargona, jasne etikete na svakodnevnom jeziku. Što točno može raditi vaš administrator župnog ureda? Sad ćete odmah znati.
+- **Pametni gumbi na nadzornoj ploči** — gumbi koji vode na nedostupne akcije više se ne prikazuju. Čišće sučelje, manje zbunjenosti za osoblje i volontere.
+- **Ekskluzivni EditSelf način rada** — volonteri mogu uređivati samo vlastite podatke, ništa više. Savršeno za veće zajednice s mnogo suradnika.
+- **Novi lokalizacijski centar** na `/admin/system/localization` — sve jezične postavke na jednom, preglednom mjestu.
+
+## Pomozite nam rasti zajedno
+
+Hrvatski je sada jedan od 55+ jezika u ChurchCRM-u. Ali to nije kraj — to je tek početak.
+
+Ako nešto u prijevodu nije sasvim točno za vaš crkveni kontekst, ili ako biste htjeli pomoći u budućim ažuriranjima prijevoda, pozivamo vas da se pridružite projektu na [POEditoru](https://poeditor.com/join/project/lEluFJMi0W). Svaki ispravak, svaka nova fraza — odlazi svim crkvama koje koriste ovaj jezik. Vaš doprinos živi dalje.
+
+Ako imate pitanja, ili jednostavno želite biti dio zajednice koja gradi alate za crkvu — dođite na naš [Discord](https://discord.gg/tuWyFzj3Nj). Dobrodošli ste.
+
+## Preuzmite ChurchCRM 7.4.1
+
+Vaš jezik. Vaši podaci. Vaša crkva.
+
+[Preuzmite ChurchCRM](https://churchcrm.io) i uvjerite se sami — besplatno, bez obveza, zauvijek.
+
+---
+
+*ChurchCRM je besplatni, open-source softver za upravljanje crkvenom zajednicom koji koriste župe u više od 55 jezika širom svijeta. [Preuzmite ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Community Discord](https://discord.gg/tuWyFzj3Nj)*


### PR DESCRIPTION
Adds the Croatian 7.4.1 launch blog post to the unified single blog (`content/en/blog/`) with `language: hr` frontmatter.

This is the new architecture per July 8 direction — no per-locale blog directories, all regional posts live here with a language tag.

**Content:** Fully in Croatian ✅
**Image:** Placeholder — `/images/blogs/741-hr.png` (Zagreb Cathedral / Church of St. Donatus, Zadar — to be added via Canvora in follow-up PR)

Depends on cleanup PR #41 being merged first (removes old /hr/ locale structure).