### PR TITLE
Blog: 7.4.1 German locale post (DSGVO / Kölner Dom)

### DIFF
--- a/content/en/blog/2026-07-08-741-de-locale.md
+++ b/content/en/blog/2026-07-08-741-de-locale.md
@@ -1,0 +1,74 @@
+---
+title: "Kirchendaten in Ihrer Hand: ChurchCRM 7.4.1 und DSGVO-konforme Kirchenverwaltung"
+date: "2026-07-08"
+lastmod: "2026-07-08"
+author: "George Dawoud"
+language: "de"
+description: "ChurchCRM 7.4.1 ist die freie, quelloffene Kirchenverwaltungssoftware für DSGVO-konforme Gemeinden in Deutschland, Österreich und der Schweiz — selbst gehostet, transparent und vollständig auditierbar."
+summary: "Erfahren Sie, warum selbst gehostete, quelloffene Software wie ChurchCRM 7.4.1 der klarste Weg zur DSGVO-Konformität für deutschsprachige Kirchengemeinden ist — und was Version 7.4.1 für Kirchenbüros und Gemeindeverwaltungen konkret bringt."
+keywords: "DSGVO Kirche, Kirchenverwaltung Software, ChurchCRM Deutsch, Open Source Kirche, selbst gehostete Kirchensoftware, Datenschutz Gemeinde, ChurchCRM 7.4.1, Kirchenmitglieder Datenschutz"
+tags: ["DSGVO", "open-source", "self-hosted", "Kirchenverwaltung", "7.4.1"]
+featured_image: "/images/blogs/741-de.jpg"
+featured_image_alt: "ChurchCRM 7.4.1 — DSGVO-konforme, selbst gehostete Kirchenverwaltungssoftware für deutschsprachige Gemeinden"
+image_credit: "Kölner Dom — Wikimedia Commons (CC BY-SA 3.0 DE, Thomas Wolf)"
+---
+
+## Ihre Kirchengemeinde verdient Software, der Sie vertrauen können
+
+Die Datenschutz-Grundverordnung — DSGVO — ist kein bürokratisches Konstrukt. Sie ist Ausdruck einer Kultur. Deutschland hat schon immer verstanden, dass Daten mehr sind als bloße Informationen: Sie sind Identität, Würde und Macht. Wenn Ihre Kirchengemeinde Namen, Adressen, Taufregister, seelsorgerliche Gesprächsnotizen und Familienbeziehungen erfasst, halten Sie etwas Heiliges in Händen. Diese Daten gehören den Menschen, denen Sie dienen — und sie müssen per Gesetz unter Ihrer Kontrolle bleiben.
+
+Genau deshalb haben wir ChurchCRM so gebaut, wie es ist: kostenlos, quelloffen und von Anfang an für den Betrieb auf Ihrem eigenen Server konzipiert.
+
+## Das DSGVO-Problem cloudbasierter Kirchensoftware
+
+Die meisten kommerziellen Kirchenverwaltungsplattformen werden in der Cloud betrieben. Die Daten Ihrer Gemeinde liegen auf Servern, die Ihnen nicht gehören, in Rechenzentren, die Sie nie besucht haben, betrieben von Unternehmen, deren Datenschutzrichtlinien sich ohne Vorankündigung ändern können. Wenn ein US-amerikanischer SaaS-Anbieter die personenbezogenen Daten Ihrer Mitglieder speichert, gehen Sie ein reales DSGVO-Risiko ein: unklare Auftragsverarbeitungsverträge, undurchsichtige Sub-Auftragnehmer-Ketten und ein grundlegender Kontrollverlust über Daten, die Ihren Kirchenmitgliedern gehören.
+
+Artikel 32 der DSGVO verpflichtet Sie, geeignete technische und organisatorische Maßnahmen zum Schutz personenbezogener Daten zu ergreifen. Die Auslagerung dieser Daten an einen Drittanbieter in der Cloud ist keine solche Maßnahme — es ist eine Verantwortungslücke, die kein Auftragsverarbeitungsvertrag vollständig schließen kann.
+
+ChurchCRM ist anders. Sie installieren es. Ihnen gehört der Server. Sie kontrollieren die Datenbank. Keine Daten verlassen Ihre Infrastruktur, es sei denn, Sie senden sie bewusst. Und weil jede Zeile Quellcode öffentlich unter der MIT-Lizenz verfügbar ist — jedes Datenbankschema, jede Zugriffskontrolle, jeder Datenpfad — können Ihre IT-Ehrenamtlichen, Ihr Kirchenrechenzentrum oder jeder zertifizierte Datenschutzbeauftragte die Software vollständig prüfen. Das ist kein Feature. Das ist die Architektur.
+
+## Gebaut für jede Kirchengemeinde im deutschsprachigen Raum
+
+Deutschlands religiöse Landschaft ist reicher und vielfältiger als jede einzelne Konfession. Die historischen evangelischen Landeskirchen und katholischen Bistümer unterhalten große, gut ausgestattete Pfarrbüros mit hauptamtlichem Gemeindeverwaltungspersonal, das Präzision, Dokumentation und Rechtssicherheit erwartet. Doch in deutschen Städten — in Berlin, Frankfurt, Hamburg, München und Stuttgart — wächst ein Netzwerk evangelikaler Migrantengemeinden, arabischsprachiger Gemeinschaften und osteuropäischer Gemeinden, die Mitglieder betreuen, die realen finanziellen Hürden gegenüberstehen. Für diese Gemeinschaften reicht „erschwinglich" nicht aus. Kostenlos ist die einzige Option.
+
+ChurchCRM ist wirklich kostenlos. Kein kostenloser Einstiegstarif. Kein Freemium-Modell mit versteckten Kosten. MIT-lizenziert, keine Pro-Mitglied-Gebühren, keine auslaufenden Testversionen, kein Upselling. Eine Gemeinde mit zwanzig Mitgliedern und eine landeskirchliche Einrichtung mit zehntausend Datensätzen nutzen exakt dieselbe Software mit exakt denselben Möglichkeiten.
+
+Österreich und die Schweiz stehen vor vergleichbaren Realitäten: Österreichs Datenschutzgesetz (DSG) und die Schweizer revDSG orientieren sich beide inhaltlich eng an der DSGVO. Selbst-Hosting ist in allen drei Ländern der sauberste und rechtlich verlässlichste Weg zur Compliance — und der einzige, der Ihre Kirche und nicht einen Anbieter in die Kontrolle bringt.
+
+## Was ist neu in ChurchCRM 7.4.1
+
+Version 7.4.1 setzt eine stetige, gemeinschaftlich getragene Weiterentwicklung der Plattform fort. Hier ist, was für Kirchenbüro-Mitarbeitende und Verwaltungsleitungen am wichtigsten ist:
+
+### Vereinfachte Berechtigungen — endlich in verständlicher Sprache
+
+Wir haben das Benutzerberechtigungssystem mit klaren, allgemeinverständlichen Bezeichnungen neu geschrieben, die jeder ohne Handbuch versteht. Kirchenbüro-Verwaltende müssen keine kryptischen Berechtigungsnamen mehr entziffern, um zu entscheiden, welche Rechte ein neuer Ehrenamtlicher erhalten soll. Intelligente Dashboard-Schaltflächen blenden Aktionen, die ein Nutzer nicht ausführen darf, nun automatisch aus — das reduziert Verwirrung und unbeabsichtigte Datenpannen.
+
+### EditSelf-Modus — Mitgliederautonomie mit Datenschutz
+
+Der neue exklusive EditSelf-Berechtigungsmodus ermöglicht es Gemeindemitgliedern, ihre eigenen Kontaktdaten zu aktualisieren, ohne Datensätze anderer Personen einsehen oder bearbeiten zu können. Das ist eine direkte Umsetzung der DSGVO: Mitglieder haben gemäß Artikel 15 und 16 das Recht auf Auskunft und Berichtigung — EditSelf macht die Umsetzung dieser Rechte praktikabel, ohne zusätzlichen Verwaltungsaufwand zu erzeugen.
+
+### Datenschutzkonforme Leitplanken direkt integriert
+
+Datenschutz ist nun strukturell verankert, nicht optional. Wir haben datenschutzfreundliche Standardeinstellungen direkt in den Verwaltungsworkflow eingebettet, sodass Mitarbeitende zu rechtskonformem Handeln angeleitet werden — ohne allein auf Schulungen angewiesen zu sein, um Fehler zu verhindern.
+
+### Ein zentrales Lokalisierungs-Hub
+
+Das neue Admin-Panel unter `admin/system/localization` bündelt alle Sprach- und Regionaleinstellungen an einem Ort. Für Kirchen, die in mehrsprachigen Umgebungen arbeiten — was in Deutschlands Migrantengemeinden weit verbreitet ist — ist die Konfiguration von ChurchCRM für eine zweisprachige Gemeinde nun unkompliziert möglich.
+
+### 55+ Sprachen und wachsend
+
+Version 7.4.1 liefert das kroatische Sprachpaket (hr_HR) aus und bringt ChurchCRM damit auf über 55 Sprachen weltweit. Eine kroatische Diaspora-Gemeinde in Wien, eine mehrsprachige Pfarrei in Basel, eine Landeskirche mit internationalem Missionspersonal — unsere Lokalisierungsbibliothek deckt eine Breite ab, die kein einzelner kommerzieller Anbieter erreichen kann, weil sie von den Gemeinschaften aufgebaut wird, die sie brauchen.
+
+## Helfen Sie, ChurchCRM für deutschsprachige Gemeinden zu gestalten
+
+Das deutsche Sprachpaket ist stark — doch jede Sprache gewinnt durch Stimmen aus der Gemeinschaft, die das spezifische Vokabular der Kirchenverwaltung, der Seelsorge und regionaler Kirchenstrukturen in Deutschland, Österreich und der Schweiz kennen. Wenn Sie als Muttersprachler in der Kirchenverwaltung tätig sind, verbessert Ihr Beitrag auf [POEditor](https://poeditor.com/join/project/lEluFJMi0W) ChurchCRM direkt für tausende Kirchengemeinden weltweit.
+
+Treten Sie dem globalen Austausch auf unserem [Community-Discord](https://discord.gg/tuWyFzj3Nj) bei, wo Kirchenverwaltende, Entwicklerinnen und Entwickler sowie Gemeindeleiterinnen und -leiter aus mehr als 55 Sprachgemeinschaften Rat, Feedback und gegenseitige Unterstützung teilen.
+
+Wenn Sie bereit sind, ChurchCRM einzusetzen: vollständige Dokumentation, Installationsanleitungen und Downloads finden Sie auf [churchcrm.io](https://churchcrm.io). Die Einrichtung des Self-Hostings ist in einem Nachmittag erledigt. Die Klarheit beim Datenschutz, die es schafft, hält Jahre.
+
+DSGVO-konform. Selbst gehostet. Open Source. Ihre Kirchendaten bleiben bei Ihrer Kirche.
+
+---
+
+*ChurchCRM ist freie, quelloffene Kirchenverwaltungssoftware, die von Gemeinden in 55+ Sprachen weltweit eingesetzt wird. [ChurchCRM herunterladen](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Community Discord](https://discord.gg/tuWyFzj3Nj)*


### PR DESCRIPTION
Adds German-language blog post for ChurchCRM 7.4.1 release.

- Language: `de`
- Target audience: German-speaking churches (DE/AT/CH), DSGVO compliance angle
- Hero: Kölner Dom (Wikimedia Commons CC BY-SA 3.0 DE)
- File: `content/en/blog/2026-07-08-741-de-locale.md`