### PR TITLE
Blog: 7.4.1 Spanish locale post (Latin America / Guadalupe)

### DIFF
--- a/content/en/blog/2026-07-09-741-es-locale.md
+++ b/content/en/blog/2026-07-09-741-es-locale.md
@@ -1,0 +1,82 @@
+---
+title: "Toda Iglesia Merece Buenas Herramientas: ChurchCRM 7.4.1 y el Auge de la Iglesia Latinoamericana"
+date: "2026-07-09"
+lastmod: "2026-07-09"
+author: "George Dawoud"
+language: "es"
+description: "ChurchCRM 7.4.1 llega con más de 55 idiomas, permisos simplificados y privacidad GDPR — herramientas gratuitas para las iglesias evangélicas y pentecostales de América Latina."
+summary: "América Latina vive un movimiento histórico de plantación de iglesias. ChurchCRM 7.4.1 ofrece software gratuito y de código abierto diseñado para las congregaciones que crecen desde las bases — sin cuotas por miembro, sin bloqueos de datos, sin barreras de idioma."
+keywords: "ChurchCRM, software para iglesias, código abierto, América Latina, gestión eclesiástica, iglesia evangélica, iglesia pentecostal, autoalojamiento, mayordomía, gratis"
+tags: ["lanzamiento", "localización", "latinoamérica", "open-source", "comunidad", "7.4.1"]
+featured_image: "/images/blogs/741-es.jpg"
+featured_image_alt: "Congregación latinoamericana reunida en adoración — ChurchCRM 7.4.1 para iglesias de habla hispana"
+image_credit: "Basílica de Guadalupe, Mexico City — Wikimedia Commons (CC BY-SA 3.0)"
+---
+
+Hay un movimiento de plantación de iglesias que está ocurriendo ahora mismo, y el mundo de la tecnología lo está ignorando por completo.
+
+En México, Colombia, Argentina, Chile, las comunidades de habla hispana de Brasil, y en cientos de ciudades entre ellas, nuevas congregaciones evangélicas y pentecostales se forman cada semana. Son iglesias de base, guiadas por el Espíritu, construidas sobre una fe relacional — el tipo de iglesia donde el pastor conoce a cada familia por su nombre, y las hermanas del ministerio de mujeres coordinan todo por WhatsApp.
+
+Estas iglesias no son pequeñas porque les falte visión. Son nuevas. Y merecen herramientas que estén a la altura de su llamado.
+
+Para eso construimos ChurchCRM.
+
+## El Sector Eclesial de Mayor Crecimiento en el Mundo
+
+Las comunidades evangélicas y pentecostales de América Latina representan una de las expansiones más extraordinarias en la historia del cristianismo. Los investigadores estiman que decenas de miles de nuevas congregaciones se forman en la región cada año — muchas de ellas reuniéndose en hogares, locales comerciales, salones alquilados y plazas al aire libre. Este crecimiento no está impulsado por denominaciones con departamentos de tecnología y presupuestos para software. Está impulsado por pastores con un llamado, voluntarios con laptops, y congregaciones que funcionan con fe y registros en papel.
+
+Y esta es la realidad que esas comunidades enfrentan todos los días: las herramientas administrativas diseñadas para iglesias fueron pensadas para organizaciones grandes y prósperas en América del Norte y Europa. Cobran por miembro. Bloquean tus datos dentro de sistemas propietarios. Asumen que tienes un equipo dedicado y un administrador con habilidades tecnológicas que habla inglés.
+
+La mayoría del mundo eclesial en crecimiento no se parece a eso. Nunca se parecerá.
+
+## Por Qué el Autoalojamiento lo Cambia Todo Aquí
+
+Cuando una iglesia en Medellín, Guadalajara o Buenos Aires paga una cuota por miembro para administrar su congregación, ese dinero no regresa a la misión. Va a un proveedor de software a miles de kilómetros de distancia que nunca ha escuchado un culto dominical en español, nunca ha visto cómo una congregación se multiplica desde una sala de estar, y no tiene idea de lo que significa la mayordomía para una comunidad que está construyendo algo desde cero.
+
+El autoalojamiento no es solo una preferencia técnica. Para una iglesia en crecimiento sin presupuesto de tecnología, es un acto de mayordomía financiera. Lo instalas una vez. Tus datos son tuyos. El costo es cero — para siempre.
+
+Sin cuotas por miembro. Sin bloqueos. Sin que ningún proveedor decida cuánto valen los datos de tu iglesia.
+
+Esa es la promesa del código abierto, y es exactamente por eso que ChurchCRM tiene licencia MIT y siempre la tendrá.
+
+## Qué Trae ChurchCRM 7.4.1
+
+### Más de 55 Idiomas — y Creciendo
+
+Con la incorporación del croata (hr_HR), ahora distribuimos ChurchCRM en más de 55 idiomas. El español ha sido compatible durante años, y esta versión refuerza nuestro compromiso de mantener cada variante local cuidada y actualizada. Si alguna vez has deseado que la interfaz de ChurchCRM se sintiera más natural en tu variante regional del español — o si quieres contribuir a la traducción — la puerta está abierta en [POEditor](https://poeditor.com/join/project/lEluFJMi0W).
+
+### Permisos Más Inteligentes, en Lenguaje Claro
+
+Una de las mayores barreras para las iglesias administradas por voluntarios es la complejidad de los permisos. ¿Quién puede ver qué? ¿Quién borra accidentalmente el directorio de miembros? La versión 7.4.1 rediseña el sistema de permisos de usuario con etiquetas en lenguaje claro y un modo de permiso exclusivo llamado **EditSelf** — para que un voluntario pueda actualizar su propio perfil sin tocar jamás el registro de nadie más. Esa es la confianza real, integrada en el software.
+
+### Panel Inteligente — Sin Confusión, Sin Desorden
+
+Cuando un nuevo voluntario inicia sesión y ve botones para acciones a las que no tiene acceso, se genera confusión y consultas de soporte. El nuevo panel inteligente oculta automáticamente las acciones inaccesibles. Tu equipo ve exactamente lo que puede hacer — nada más, nada menos.
+
+### Salvaguardas de Privacidad Compatibles con GDPR
+
+La privacidad de los datos importa en todas partes — incluso en regiones donde aún no es un requisito legal. Hemos añadido salvaguardas de privacidad compatibles con GDPR para que puedas construir una cultura de mayordomía de datos desde el primer día.
+
+### Nuevo Centro de Localización
+
+Encuentra todo en un solo lugar: **Admin → Sistema → Localización**. Configuración de idioma, formatos regionales, gestión de variantes locales — todo consolidado para que tu administrador no tenga que buscar entre menús.
+
+## De los Grupos de WhatsApp a una Base de Datos Real
+
+Sabemos cómo la mayoría de las iglesias en crecimiento gestionan a sus miembros hoy en día: un grupo de WhatsApp para el equipo de adoración, una hoja de cálculo que alguien hizo en 2019, un registro en papel que vive en el maletín del pastor, y mucha información guardada en la memoria de unos pocos voluntarios clave.
+
+Cuando ese voluntario se muda. Cuando se pierde el teléfono. Cuando la congregación crece más allá de 80 personas y nadie puede recordar quién fue bautizado y cuándo — las grietas empiezan a aparecer.
+
+ChurchCRM es el paso adelante que no requiere presupuesto. Instálalo en un servidor de $5 al mes, una computadora donada que funcione localmente, o el plan de alojamiento compartido que el hermano más techie de la congregación ya tiene. Importa a tus miembros. Comienza a registrar asistencia, compromisos, grupos y eventos. Tus datos siguen siendo tuyos — privados, portátiles y libres de los términos de servicio de cualquier proveedor.
+
+## Únete a Nosotros — Construye las Herramientas que la Iglesia Global Merece
+
+ChurchCRM tiene 903 estrellas en GitHub, 551 bifurcaciones, y más de diez años de comunidad detrás. Cada iglesia que instala ChurchCRM, cada voluntario que mejora una traducción, cada pastor que se lo recomienda a otro pastor — así es como crecemos.
+
+¿Quieres ayudar a traducir ChurchCRM a tu variante regional del español? Únete en [POEditor](https://poeditor.com/join/project/lEluFJMi0W). ¿Tienes preguntas o quieres conectarte con la comunidad? Únete a nuestro [servidor de Discord](https://discord.gg/tuWyFzj3Nj). ¿Listo para instalar? Visita [churchcrm.io](https://churchcrm.io).
+
+Toda iglesia merece grandes herramientas. Esta es tuya — sin condiciones.
+
+---
+
+*ChurchCRM es software gratuito de gestión eclesial de código abierto utilizado por congregaciones en 55+ idiomas en todo el mundo. [Descarga ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Discord comunitario](https://discord.gg/tuWyFzj3Nj)*


### PR DESCRIPTION
Adds Spanish-language blog post for ChurchCRM 7.4.1 release.

- Language: `es`
- Target audience: Latin American churches, Mexico / Colombia / Argentina focus
- Hero: Basílica de Guadalupe (Wikimedia Commons CC BY-SA 3.0)
- File: `content/en/blog/2026-07-09-741-es-locale.md`