### PR TITLE
Blog: 7.4.1 Portuguese locale post (Brazil megachurches)

### DIFF
--- a/content/en/blog/2026-07-10-741-pt-locale.md
+++ b/content/en/blog/2026-07-10-741-pt-locale.md
@@ -1,0 +1,63 @@
+---
+title: "Da Megaigreja à Comunidade de Fé: O Mesmo Software, Custo Zero"
+date: "2026-07-10"
+lastmod: "2026-07-10"
+author: "George Dawoud"
+language: "pt"
+description: "ChurchCRM 7.4.1 em português: software gratuito e de código aberto para igrejas de todos os tamanhos, com soberania de dados e custo zero."
+summary: "Da maior megaigreja à menor comunidade de fé, o ChurchCRM 7.4.1 chega em português com novos recursos de permissões, painel inteligente e suporte completo à localização — sem mensalidades, sem taxas por membro, para sempre."
+keywords: "software gestão igrejas, ChurchCRM português, open source igreja, software gratuito para igrejas, gestão de membros, código aberto evangélico, sistema igrejas brasil, ChurchCRM brasil"
+tags: ["lançamento", "localização", "português", "brasil", "open-source", "comunidade"]
+featured_image: "/images/blogs/741-pt.jpg"
+featured_image_alt: "ChurchCRM 7.4.1 com suporte completo ao português — software gratuito de gestão de igrejas para congregações brasileiras e lusófonas"
+image_credit: "Catedral da Sé, São Paulo — Wikimedia Commons (CC0)"
+---
+
+Da maior megaigreja à menor comunidade de fé — o mesmo software, o mesmo custo: zero.
+
+Isso não é slogan publicitário. É uma declaração sobre a forma como construímos o ChurchCRM — e é o motivo pelo qual celebramos hoje o suporte completo à localização em português.
+
+Seja você o administrador de uma Assembleia de Deus com 10.000 cadeiras ocupadas no culto de domingo, ou o único voluntário de uma comunidade de fé no interior do Mato Grosso que gerencia tudo pelo celular entre os cultos — você recebe o mesmo software. Sem planos escalonados. Sem preço por membro que pune o crescimento. Sem aprisionamento. Custo zero.
+
+## O Coração da Igreja Brasileira
+
+O Brasil não é simplesmente um grande mercado. É o epicentro do crescimento evangélico mundial. A Igreja Evangélica no Brasil é um dos movimentos mais dinâmicos, populares e espiritualmente vivos do planeta — e funciona com base em relacionamentos, comunidade e sacrifício. Das grandes megaigrejas de São Paulo e do Rio de Janeiro a milhares de pequenas comunidades plantadas por pastores leigos em favelas e cidades do sertão, a igreja brasileira é ao mesmo tempo incrivelmente sofisticada e profundamente humilde.
+
+E essas mesmas igrejas têm enfrentado uma realidade dolorosa: a maioria dos softwares de gestão eclesiástica é precificada para congregações norte-americanas e europeias. Taxas por membro. Mensalidades cotadas em dólares. Funcionalidades bloqueadas por planos pagos. Contratos pensados para tornar a saída mais difícil do que a permanência. Uma congregação de 25 irmãos em Recife não deveria pagar a mesma mensalidade que uma megaigreja nos subúrbios de Dallas — e ainda assim, é exatamente isso que as estruturas de preços costumam parecer.
+
+*Isso não é justo.* E foi isso que nos propusemos a mudar.
+
+## Por Que Software Livre e Auto-Hospedado Muda Tudo
+
+Quando o software é auto-hospedado e licenciado sob a MIT, o cálculo muda completamente. Seus dados ficam no seu servidor — não na nuvem de terceiros, não sujeitos a mudanças nos termos de serviço, não reféns das decisões de preço de um fornecedor. Para igrejas no Brasil, em Portugal, em Angola e em Moçambique, isso importa de formas que vão muito além do custo:
+
+- **Soberania de dados.** Cadastro de membros, histórico de dízimos, anotações pastorais — tudo pertence à sua congregação, ponto final.
+- **Sem risco cambial.** Nenhuma assinatura em dólar que dobra silenciosamente em reais quando o câmbio vira.
+- **Pertence à comunidade.** Mantido por uma comunidade global de desenvolvedores e voluntários de igrejas — pessoas exatamente como as suas.
+- **Durabilidade.** Estamos nessa há mais de 10 anos, com 903 estrelas no GitHub, 551 forks e uma comunidade que cresce todo mês.
+
+As igrejas brasileiras já estão entre as comunidades de fé mais engajadas digitalmente do mundo. Células, grupos de louvor, ministérios de evangelismo — tudo cada vez mais gerenciado com ferramentas digitais. Vocês merecem um software construído para estar à altura dessa sofisticação, a um preço que condiz com o chamado que vocês receberam.
+
+## O Que o ChurchCRM 7.4.1 Traz
+
+- **Permissões de usuário simplificadas com rótulos em linguagem simples.** Chega de decifrar o que um nível de permissão significa na prática. Cada função é descrita em palavras que seus coordenadores de voluntários e equipe administrativa entendem sem precisar de manual.
+- **Botões inteligentes no painel que ocultam ações inacessíveis.** Sua equipe vê apenas o que realmente pode fazer. Menos confusão, menos cliques acidentais, voluntários mais confiantes.
+- **Modo de permissão exclusivo EditSelf.** Os membros podem atualizar seus próprios dados de contato sem acessar os registros de ninguém mais — limpo, simples e adequado para congregações de qualquer tamanho.
+- **Salvaguardas de privacidade compatíveis com a LGPD e o RGPD.** Mesmo que sua igreja atue fora da União Europeia, essas proteções refletem as melhores práticas de cuidado com os dados dos membros — e estão alinhadas à Lei Geral de Proteção de Dados do Brasil.
+- **Novo hub de localização em admin/system/localization.** Gerencie todas as configurações de idioma em uma interface clara e única.
+
+E o português? Suporte completo — seja Português do Brasil ou Português Europeu, falamos a sua língua.
+
+## Junte-se ao Movimento
+
+*A comunidade é o projeto.* Cada igreja que instala o ChurchCRM, cada voluntário que aprimora uma tradução, cada pastor que indica o sistema para outro pastor — é assim que crescemos.
+
+- **Contribua com a tradução:** [POEditor](https://poeditor.com/join/project/lEluFJMi0W) — adicione ou refine strings em português diretamente, e sua contribuição estará no próximo lançamento.
+- **Entre na comunidade:** [Discord](https://discord.gg/tuWyFzj3Nj) — conecte-se com desenvolvedores, administradores de igrejas e voluntários de dezenas de países.
+- **Baixe e instale:** [churchcrm.io](https://churchcrm.io) — gratuito, auto-hospedado, para sempre.
+
+Cada igreja que instala o ChurchCRM, cada voluntário que aprimora uma tradução, cada pastor que indica a um irmão — é assim que crescemos. Não por meio de capital de risco nem de funis de vendas agressivos. Por meio de pessoas que acreditam que o *corpo de Cristo* merece um software tão generoso quanto o evangelho que ele prega.
+
+---
+
+*ChurchCRM é um software gratuito e de código aberto para gestão de igrejas, usado por congregações em 55+ idiomas em todo o mundo. [Baixe o ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Discord da comunidade](https://discord.gg/tuWyFzj3Nj)*


### PR DESCRIPTION
Adds Portuguese (Brazilian) blog post for ChurchCRM 7.4.1 release.

- Language: `pt`
- Target audience: Brazilian churches, megachurch to small community angle
- Hero: Catedral da Sé, São Paulo (Wikimedia Commons CC0)
- File: `content/en/blog/2026-07-10-741-pt-locale.md`