### PR TITLE
Blog: 7.4.1 French locale post (Francophone Africa)

### DIFF
--- a/content/en/blog/2026-07-11-741-fr-locale.md
+++ b/content/en/blog/2026-07-11-741-fr-locale.md
@@ -1,0 +1,62 @@
+---
+title: "ChurchCRM 7.4.1 : Bienvenue, Église francophone mondiale"
+date: "2026-07-11"
+lastmod: "2026-07-11"
+author: "George Dawoud"
+language: "fr"
+description: "ChurchCRM 7.4.1 est disponible en français — pour l'Afrique francophone, la France, la Belgique et le Québec. Gratuit, open source, auto-hébergé."
+summary: "Le centre de la croissance chrétienne mondiale est en Afrique francophone — et ChurchCRM parle votre langue."
+keywords: "ChurchCRM français, logiciel gestion église, Afrique chrétienne, open source église, auto-hébergé, RGPD, gratuit"
+tags: ["localization", "French", "Francophone Africa", "open-source", "release"]
+featured_image: "/images/blogs/741-fr.jpg"
+featured_image_alt: "Basilique Notre-Dame de la Paix de Yamoussoukro — ChurchCRM 7.4.1 pour l'Église francophone mondiale"
+image_credit: "Basilique Notre-Dame de la Paix, Yamoussoukro — Wikimedia Commons (CC0)"
+---
+
+## Le centre de la croissance chrétienne mondiale vous appartient
+
+Le christianisme croît plus vite en Afrique francophone qu'en n'importe quelle autre région du monde. La République démocratique du Congo — plus grand pays francophone par population — abrite plus de 80 millions de chrétiens, répartis dans des milliers de paroisses, d'Églises évangéliques et de communautés locales. Côte d'Ivoire, Cameroun, Sénégal, Rwanda, Burundi, Madagascar : autant de pays où l'Église est vivante, en expansion, et souvent sous-équipée.
+
+ChurchCRM 7.4.1 est maintenant disponible entièrement en français.
+
+## Un logiciel construit pour l'Église mondiale — pas seulement pour l'Occident
+
+La plupart des logiciels de gestion d'Église sont conçus et tarifés pour des paroisses nord-américaines ou européennes. Pour une communauté de Kinshasa, d'Abidjan ou de Douala, ces coûts sont inaccessibles.
+
+ChurchCRM est gratuit. Pas de frais par membre. Pas d'abonnement mensuel. Pas de surprises sur votre facture. Vous téléchargez, vous installez sur votre propre serveur, et vous commencez à gérer votre congrégation — le tout sans débourser un centime.
+
+C'est la même plateforme utilisée par des milliers d'Églises dans 55+ langues à travers le monde. Et maintenant, elle parle votre langue.
+
+## Auto-hébergé : vos données restent dans votre Église
+
+Dans un contexte où la souveraineté numérique est de plus en plus importante — en Afrique comme en Europe — ChurchCRM offre une garantie simple : **vos données n'ont jamais besoin de quitter votre serveur**.
+
+Pas de cloud imposé. Pas de vendor qui détient vos registres de membres. Pas de dépendance envers une entreprise étrangère. Vous choisissez où vos données sont hébergées, et vous en restez propriétaire.
+
+Pour les Églises en France et en Belgique, cela signifie également une conformité naturelle avec le **RGPD** — le Règlement Général sur la Protection des Données. Les données de vos membres sont sous votre contrôle, auditables, exportables, et supprimables à tout moment.
+
+## Ce que la version 7.4.1 apporte
+
+En plus du support complet du français, ChurchCRM 7.4.1 comprend :
+
+- **Permissions utilisateur simplifiées** — des libellés en langage clair, sans jargon technique
+- **Tableau de bord intelligent** — les boutons qui ne vous sont pas accessibles disparaissent automatiquement
+- **Mode EditSelf exclusif** — permettez aux membres de mettre à jour leurs propres informations
+- **Hub de localisation** — gérez toutes vos traductions depuis un seul endroit (admin/system/localization)
+- **Garde-fous RGPD** — des outils de confidentialité intégrés pour protéger les données personnelles
+
+## Pour les Églises diaspora en France
+
+Paris, Lyon, Marseille : des dizaines de milliers de chrétiens congolais, camerounais, ivoiriens et sénégalais constituent des communautés vivantes dans les grandes villes françaises. Ces Églises diaspora font le pont entre deux contextes — et ChurchCRM peut servir les deux : le français métropolitain et le français d'Afrique, dans la même installation.
+
+## Contribuez à votre langue
+
+ChurchCRM est un projet communautaire. Si vous souhaitez améliorer la traduction française, corriger une formulation ou ajouter du vocabulaire spécifique à votre contexte ecclésiastique, rejoignez-nous sur POEditor :
+
+→ [Contribuer à la traduction française](https://poeditor.com/join/project/lEluFJMi0W)
+
+Rejoignez notre communauté : [Discord](https://discord.gg/tuWyFzj3Nj)
+
+---
+
+*ChurchCRM est un logiciel libre de gestion d'Église, utilisé par des congrégations dans 55+ langues à travers le monde. [Télécharger ChurchCRM](https://churchcrm.io) · [GitHub](https://github.com/ChurchCRM/CRM) · [Discord communautaire](https://discord.gg/tuWyFzj3Nj)*


### PR DESCRIPTION
Adds French-language blog post for ChurchCRM 7.4.1 release.

- Language: `fr`
- Target audience: Francophone Africa (DRC, Côte d'Ivoire, Cameroun) + diaspora in France/Belgium
- Hero: Basilique Notre-Dame de la Paix, Yamoussoukro (Wikimedia Commons CC0)
- File: `content/en/blog/2026-07-11-741-fr-locale.md`